### PR TITLE
Set signature image to nil when cleared

### DIFF
--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -57,10 +57,7 @@ public class SwiftSignatureView: UIView {
     
     // MARK: Public Methods
     public func clear() {
-        let rect = self.bounds
-        UIGraphicsBeginImageContext(rect.size)
-        signature = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+        signature = nil
         self.setNeedsDisplay()
     }
     


### PR DESCRIPTION
In order to detect if the user cleared the signature the image should be set to nil.