### PR TITLE
Fixed pod spec to make it compatible with Cocoapods 1.0 & Swift 2.2

### DIFF
--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -69,10 +69,10 @@ public class SwiftSignatureView: UIView {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         
-        let tap:UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: "tap:")
+        let tap:UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(SwiftSignatureView.tap(_:)))
         self.addGestureRecognizer(tap)
         
-        let pan:UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: "pan:")
+        let pan:UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(SwiftSignatureView.pan(_:)))
         pan.minimumNumberOfTouches = 1
         pan.maximumNumberOfTouches = 1
         self.addGestureRecognizer(pan)

--- a/SwiftSignatureView.podspec
+++ b/SwiftSignatureView.podspec
@@ -4,11 +4,10 @@ Pod::Spec.new do |s|
   s.summary          = "A lightweight, fast and customizable option for capturing signatures within your app."
 
   s.description      = <<-DESC
-                       SwiftSignatureView is a lightweight, fast and customizable option for capturing signatures within your app. You can retrieve the signature as a UIImage. 
+                       SwiftSignatureView is a lightweight, fast and customizable option for capturing signatures within your app. You can retrieve the signature as a UIImage.
                        DESC
 
   s.homepage         = "https://github.com/alankarmisra/SwiftSignatureView"
-  # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license          = 'MIT'
   s.author           = { "Alankar Misra" => "alankarmisra@gmail.com" }
   s.source           = { :git => "https://github.com/alankarmisra/SwiftSignatureView.git", :tag => s.version.to_s }
@@ -18,11 +17,4 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'SwiftSignatureView' => ['Pod/Assets/*.png']
-  }
-
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
 end


### PR DESCRIPTION
The problem is that latest Cocoapods (1.0) don't generate resource bundle if there're no resources. However the target for the resource bundle is generated, which results in build failures. 

Since there're no resources added to project I've removed the declaration from pod spec. 

This PR also fixes 2 warnings generated by Swift 2.2, making this pod fully compatible with Swift 2.2. 