### PR TITLE
Using the mainScreen's scale for image contexts

### DIFF
--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -91,7 +91,7 @@ public class SwiftSignatureView: UIView {
     func tap(tap:UITapGestureRecognizer) {
         let rect = self.bounds
         
-        UIGraphicsBeginImageContext(rect.size)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.mainScreen().scale)
         if(signature == nil) {
             signature = UIGraphicsGetImageFromCurrentImageContext()
         }
@@ -113,7 +113,7 @@ public class SwiftSignatureView: UIView {
             let strokeLength = distance(previousPoint, pt2: currentPoint)
             if(strokeLength >= 1.0) {
                 let rect = self.bounds
-                UIGraphicsBeginImageContext(rect.size)
+                UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.mainScreen().scale)
                 if(signature == nil) {
                     signature = UIGraphicsGetImageFromCurrentImageContext()
                 }


### PR DESCRIPTION
There are two image contexts created with UIGraphicsBeginImageContext. From the docs:

"This function is equivalent to calling the UIGraphicsBeginImageContextWithOptions function with the opaque parameter set to false and a scale factor of 1.0."

This means that on retina displays, the signature appears pixelated. I have therefore replaced UIGraphicsBeginImageContext with UIGraphicsBeginImageContextWithOptions, using false for opaque, and UIScreen.mainScreen().scale for the scale factor, so the image is always the same scale factor as the device it is being used on.