### PR TITLE
Fix Swift 4 Error by exposing methods to objc.

### DIFF
--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -96,7 +96,7 @@ open class SwiftSignatureView: UIView {
         self.addGestureRecognizer(pan)
     }
     
-    func tap(_ tap:UITapGestureRecognizer) {
+    @objc func tap(_ tap:UITapGestureRecognizer) {
         let rect = self.bounds
         
         UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.main.scale)
@@ -113,7 +113,7 @@ open class SwiftSignatureView: UIView {
         self.delegate?.swiftSignatureViewDidTapInside(self)
     }
     
-    func pan(_ pan:UIPanGestureRecognizer) {
+    @objc func pan(_ pan:UIPanGestureRecognizer) {
         switch(pan.state) {
         case .began:
             previousPoint = pan.location(in: self)


### PR DESCRIPTION
This fixes an error i had in XCode 9/Swift 4 when integrating `SwiftSignatureView` via CocoaPods