### PR TITLE
Change origin of stroke to initial touch location

### DIFF
--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -14,7 +14,7 @@ public protocol SwiftSignatureViewDelegate: class {
 }
 
 /// A lightweight, fast and customizable option for capturing fluid, variable-stroke-width signatures within your app.
-open class SwiftSignatureView: UIView {
+open class SwiftSignatureView: UIView, UIGestureRecognizerDelegate {
     // MARK: Public Properties
 
     open weak var delegate: SwiftSignatureViewDelegate?
@@ -111,6 +111,7 @@ open class SwiftSignatureView: UIView {
         let pan:UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(SwiftSignatureView.pan(_:)))
         pan.minimumNumberOfTouches = 1
         pan.maximumNumberOfTouches = 1
+        pan.delegate = self
         self.addGestureRecognizer(pan)
     }
     
@@ -131,12 +132,15 @@ open class SwiftSignatureView: UIView {
         self.delegate?.swiftSignatureViewDidTapInside(self)
     }
     
-    @objc func pan(_ pan:UIPanGestureRecognizer) {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        previousPoint = touch.location(in: self)
+        previousEndPoint = previousPoint
+        return true
+    }
+    
+    @objc public func pan(_ pan:UIPanGestureRecognizer) {
         switch(pan.state) {
-        case .began:
-            previousPoint = pan.location(in: self)
-            previousEndPoint = previousPoint
-        case .changed:
+        case .began, .changed:
             let currentPoint = pan.location(in: self)
             let strokeLength = distance(previousPoint, pt2: currentPoint)
             if(strokeLength >= 1.0) {


### PR DESCRIPTION
Current implementation starts the stroke when the touch becomes recognized which is already not at the start point of the touch.

Solution based on https://stackoverflow.com/a/60592833/384309

### Before Fix

![before-fix](https://user-images.githubusercontent.com/233144/81931404-563dd480-95ea-11ea-84ef-5b0e241c8e82.gif)

### After Fix
![after-fix](https://user-images.githubusercontent.com/233144/81931414-59d15b80-95ea-11ea-9a4a-54b7dc58d11d.gif)
CC @eumes