### PR TITLE
Added a Package manifest for Swift 5.3 to resolve the Xcode 12 warning

### DIFF
--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "SwiftSignatureView",
+    platforms: [.iOS(.v9), .tvOS(.v9)],
+    products: [
+        .library(name: "SwiftSignatureView", targets: ["SwiftSignatureView"])
+    ],
+    targets: [
+        .target(name: "SwiftSignatureView", path: "Pod"),
+        .testTarget(name: "SwiftSignatureViewTest", dependencies: ["SwiftSignatureView"], path: "Example/Tests")
+    ]
+)


### PR DESCRIPTION
Adding this library into Swift Package Manager using Xcode 12 generates a following warning
"The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99."
There are a couple solutions to this:

1.  Deployment target can be increased to _.iOS(.v9)_ in the main Package.swift file.

1. A separate Package manifest can be created to target a specific swift version.

I went the second way to make changes smaller.