### PR TITLE
PKCanvasView is transparent in order to place background below

### DIFF
--- a/Pod/Classes/PencilKitSignatureView.swift
+++ b/Pod/Classes/PencilKitSignatureView.swift
@@ -13,7 +13,17 @@ open class PencilKitSignatureView: UIView, ISignatureView {
 
     private var viewReady: Bool = false
 
-    private lazy var canvas: PKCanvasView = PKCanvasView(frame: CGRect.zero)
+    private lazy var canvas: PKCanvasView = {
+        let canvas = PKCanvasView(frame: CGRect.zero)
+        canvas.backgroundColor = .clear
+        canvas.isOpaque = false
+        canvas.overrideUserInterfaceStyle = .light
+        canvas.allowsFingerDrawing = true
+        canvas.delegate = self
+        canvas.translatesAutoresizingMaskIntoConstraints = false
+       
+        return canvas
+    }()
 
     // MARK: Public Properties
 
@@ -117,10 +127,6 @@ open class PencilKitSignatureView: UIView, ISignatureView {
     }
 
     private func initialize() {
-        self.backgroundColor = UIColor.black
-        canvas.allowsFingerDrawing = true
-        canvas.delegate = self
-        canvas.translatesAutoresizingMaskIntoConstraints = false
         addSubview(canvas)
         resetTool()
         configGestureRecognizer()


### PR DESCRIPTION
`PKCanvasView` has now transparent `backgroundColor`. This allows customizing the background of the overall `SwiftSignatureView` instance, including changing color and operating on its layer (e.g. `cornerRadius`)