### PR TITLE
Scroll view support

### DIFF
--- a/Pod/Classes/LegacySignatureView.swift
+++ b/Pod/Classes/LegacySignatureView.swift
@@ -14,6 +14,9 @@ open class LegacySwiftSignatureView: UIView, UIGestureRecognizerDelegate, ISigna
     open weak var delegate: SwiftSignatureViewDelegate?
 
     open var scale: CGFloat = 10.0
+    
+    /// The gesture recognizer that the canvas uses to track touch events.
+    private(set) open var drawingGestureRecognizer: UIGestureRecognizer?
 
     /**
     The maximum stroke width.
@@ -169,6 +172,8 @@ open class LegacySwiftSignatureView: UIView, UIGestureRecognizerDelegate, ISigna
         pan.maximumNumberOfTouches = 1
         pan.delegate = self
         self.addGestureRecognizer(pan)
+        
+        self.drawingGestureRecognizer = pan
     }
 
     @objc func tap(_ tap: UITapGestureRecognizer) {

--- a/Pod/Classes/PencilKitSignatureView.swift
+++ b/Pod/Classes/PencilKitSignatureView.swift
@@ -20,6 +20,11 @@ open class PencilKitSignatureView: UIView, ISignatureView {
     open weak var delegate: SwiftSignatureViewDelegate?
 
     open var scale: CGFloat = 10.0
+    
+    /// The gesture recognizer that the canvas uses to track touch events.
+    open var drawingGestureRecognizer: UIGestureRecognizer? {
+        return canvas.drawingGestureRecognizer
+    }
 
     /**
     The maximum stroke width.
@@ -93,7 +98,7 @@ open class PencilKitSignatureView: UIView, ISignatureView {
     open func redo() {
         canvas.undoManager?.redo()
     }
-
+    
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         initialize()

--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -18,6 +18,7 @@ public protocol ISignatureView: class {
     var strokeAlpha: CGFloat { get set }
     var signature: UIImage? { get set }
     var isEmpty: Bool { get }
+    var drawingGestureRecognizer: UIGestureRecognizer? { get }
 
     func clear(cache: Bool)
     func undo()
@@ -131,6 +132,11 @@ open class SwiftSignatureView: UIView, ISignatureView {
         }
     }
 
+    /// The gesture recognizer that the canvas uses to track touch events.
+    open var drawingGestureRecognizer: UIGestureRecognizer? {
+        return instance.drawingGestureRecognizer
+    }
+    
     /**
     Clear the signature.
     */


### PR DESCRIPTION
Exposed the drawing gesture recognizer to allow drawing when the view is placed within a `UIScrollView`. In order for the `UIScrollView` to not interfere with the drawing gesture recognizer you will need to perform:
```
if let gesture = signatureView.drawingGestureRecognizer {
    scrollView.panGestureRecognizer.require(toFail: gesture)
}
````
