### PR TITLE
Replace `class` keyword with `AnyObject`

### DIFF
--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import PencilKit
 
-public protocol ISignatureView: class {
+public protocol ISignatureView: AnyObject {
     var delegate: SwiftSignatureViewDelegate? { get set }
     var scale: CGFloat { get set }
     var maximumStrokeWidth: CGFloat { get set }

--- a/Pod/Classes/SwiftSignatureViewDelegate.swift
+++ b/Pod/Classes/SwiftSignatureViewDelegate.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public protocol SwiftSignatureViewDelegate: class {
+public protocol SwiftSignatureViewDelegate: AnyObject {
     func swiftSignatureViewDidDrawGesture(_ view: ISignatureView, _ tap: UIGestureRecognizer)
     func swiftSignatureViewDidDraw(_ view: ISignatureView)
 }


### PR DESCRIPTION
`class` is deprecated in favor of `AnyObject` for protocol inheritance.