### PR TITLE
Fix warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' i…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftSignatureView",
-    platforms: [.iOS(.v8), .tvOS(.v9)],
+    platforms: [.iOS(.v9), .tvOS(.v9)],
     products: [
         .library(name: "SwiftSignatureView", targets: ["SwiftSignatureView"])
     ],


### PR DESCRIPTION
Fix warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.0.99.