### PR TITLE
canvas and instance property set to public

### DIFF
--- a/Pod/Classes/PencilKitSignatureView.swift
+++ b/Pod/Classes/PencilKitSignatureView.swift
@@ -145,7 +145,7 @@ open class PencilKitSignatureView: UIView, ISignatureView {
         delegate?.swiftSignatureViewDidDrawGesture(self, gesture)
     }
 
-    fileprivate func scale(_ rect: CGRect, byFactor factor: CGFloat) -> CGRect {
+    public func scale(_ rect: CGRect, byFactor factor: CGFloat) -> CGRect {
         var scaledRect = rect
         scaledRect.origin.x *= factor
         scaledRect.origin.y *= factor

--- a/Pod/Classes/PencilKitSignatureView.swift
+++ b/Pod/Classes/PencilKitSignatureView.swift
@@ -13,7 +13,7 @@ open class PencilKitSignatureView: UIView, ISignatureView {
 
     private var viewReady: Bool = false
 
-    private lazy var canvas: PKCanvasView = PKCanvasView(frame: CGRect.zero)
+    public lazy var canvas: PKCanvasView = PKCanvasView(frame: CGRect.zero)
 
     // MARK: Public Properties
 

--- a/Pod/Classes/SwiftSignatureView.swift
+++ b/Pod/Classes/SwiftSignatureView.swift
@@ -37,7 +37,7 @@ open class SwiftSignatureView: UIView, ISignatureView {
 
     private var viewReady: Bool = false
 
-    private lazy var instance: ISignatureView = {
+    public lazy var instance: ISignatureView = {
         if #available(iOS 13.0, *) {
             return PencilKitSignatureView(frame: bounds)
         }


### PR DESCRIPTION
I changed the `canvas` property from `PencilKitSignatureView` and the `instance` property from `SwiftSignatureView` to `public` to implement an easy way to customize those views without the need to modify the library.