### PR TITLE
VisionOS compatible now, removed support for deprecated platforms.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,12 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
 let package = Package(
     name: "SwiftSignatureView",
-    platforms: [.iOS(.v8), .tvOS(.v9)],
+    platforms: [.iOS(.v12),
+                .tvOS(.v12),
+                .visionOS(.v1)],
     products: [
         .library(name: "SwiftSignatureView", targets: ["SwiftSignatureView"])
     ],

--- a/Pod/Classes/LegacySignatureView.swift
+++ b/Pod/Classes/LegacySignatureView.swift
@@ -15,6 +15,14 @@ open class LegacySwiftSignatureView: UIView, UIGestureRecognizerDelegate, ISigna
 
     open var scale: CGFloat = 10.0
     
+    private var currentScreenScale: CGFloat {
+        #if os(visionOS)
+        return self.traitCollection.displayScale
+        #else
+        return UIScreen.main.scale
+        #endif
+    }
+    
     /// The gesture recognizer that the canvas uses to track touch events.
     private(set) open var drawingGestureRecognizer: UIGestureRecognizer?
 
@@ -188,7 +196,7 @@ open class LegacySwiftSignatureView: UIView, UIGestureRecognizerDelegate, ISigna
     @objc func tap(_ tap: UITapGestureRecognizer) {
         let rect = self.bounds
 
-        UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, currentScreenScale)
         if signature == nil {
             signature = UIGraphicsGetImageFromCurrentImageContext()
         }
@@ -220,7 +228,7 @@ open class LegacySwiftSignatureView: UIView, UIGestureRecognizerDelegate, ISigna
             if strokeLength >= 1.0 {
 
                 let rect = self.bounds
-                UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.main.scale)
+                UIGraphicsBeginImageContextWithOptions(rect.size, false, currentScreenScale)
 
                 if signature == nil {
                     signature = UIGraphicsGetImageFromCurrentImageContext()
@@ -328,7 +336,7 @@ open class LegacySwiftSignatureView: UIView, UIGestureRecognizerDelegate, ISigna
 
     fileprivate func redraw() {
         let rect = self.bounds
-        UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, currentScreenScale)
         if signature == nil {
               signature = UIGraphicsGetImageFromCurrentImageContext()
         }


### PR DESCRIPTION
Very simple update:

- Updated the Swift Package version to 5.9
- Updated the platform minimums to v12 since older is now deprecated
- Added VisionOS support
- Added a Preview to the SwiftSignatureView (see below)

<img width="2072" height="1476" alt="Screenshot 2025-07-12 at 9 56 25 AM" src="https://github.com/user-attachments/assets/28d38c44-ae6e-416e-8f0c-08411ef27dde" />